### PR TITLE
Update base image to rust v.160

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.55.0-nightly-2021-06-21
+FROM clux/muslrust:1.60.0-stable
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why
Bumping rust version to get access to dep feature flags

# Diagram
Does this PR require a change to the application or network diagram? No

# How
Update dockerfile with rust v1.60.0
