### PR TITLE
Create 1.66 nightly version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.65.0-nightly-2022-09-17
+FROM clux/muslrust:1.66.0-nightly-2022-10-30
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why
Need a 1.66 nightly version for use in Relay since the latest Sentry version uses let ... else

# How
Bumped the version of clux/muslrust