### PR TITLE
Donal/create-1.70-nightly-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.66.0-nightly-2022-10-30
+FROM clux/muslrust:1.70.0-nightly-2023-03-22
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why
Creating a nightly version to pull in private registry's without exposing the registry token

# Diagram
No

# How
Nightly on 1.70 supports registry-auth
