### PR TITLE
add rust 1.68 stable toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.70.0-nightly-2023-03-22
+FROM clux/muslrust:1.68.2-stable
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why
Support 1.68.2 in static builds to get support for sparse registries

# Diagram
—

# How
Update base image
