### PR TITLE
Bump to 1.74.1-stable to get OnceCell support in std

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.68.2-stable
+FROM clux/muslrust:1.74.1-stable
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why
We've started using oncecell from std in cages. Need to use a later version of rust. 

# Diagram
No

# How
bump base image to 1.74.1-stable
