### PR TITLE
Merge 1.73.0 stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.68.2-stable
+FROM clux/muslrust:1.73.0-stable
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why
Adding 1.73.0 stable to the static builder

# How
Update base image.

This has already been released from the head branch, merging for visibility
